### PR TITLE
Support for shorthand _(), _p(), _n(), _pn(), expanded c# extensions and --order sorting method

### DIFF
--- a/src/GetText.Extractor/Engine/SourceResolver/DirectorySourceResolver.cs
+++ b/src/GetText.Extractor/Engine/SourceResolver/DirectorySourceResolver.cs
@@ -21,7 +21,10 @@ namespace GetText.Extractor.Engine.SourceResolver
 
         private static IEnumerable<string> GetCSharpFilesFromFolder(string folder)
         {
-            return Directory.EnumerateFiles(folder, "*.cs").Concat(
+            return Directory.EnumerateFiles(folder, "*.cs")
+                .Concat(Directory.EnumerateFiles(folder, "*.razor"))
+                .Concat(Directory.EnumerateFiles(folder, "*.cshtml"))
+                .Concat(
                 Directory.EnumerateDirectories(folder).Where(d => !excludedFolders.Contains(Path.GetFileName(d), StringComparer.OrdinalIgnoreCase)).
                 SelectMany(subdir => GetCSharpFilesFromFolder(subdir)));
         }


### PR DESCRIPTION
Made a small change to ```GetText.Extractor``` to find strings using a shorthand syntax, like:

```cs
_("Hello, World!"); // GetString
_n("You have {0} apple.", "You have {0} apples.", count, count); // GetPluralString
_p("Context", "Hello, World!"); // GetParticularString
_pn("Context", "You have {0} apple.", "You have {0} apples.", count, count); // GetParticularPluralString
```
A simple static class with such extensions is here: https://github.com/VitaliiTsilnyk/NGettext/blob/master/samples/NGettextShortSyntax.cs