### PR TITLE
ParserBase: check argument count

### DIFF
--- a/src/GetText.Extractor/Engine/ParserBase.cs
+++ b/src/GetText.Extractor/Engine/ParserBase.cs
@@ -52,28 +52,40 @@ namespace GetText.Extractor.Engine
                 switch (methodName)
                 {
                     case "GetString":   //first argument is message id
-                        messageId = ExtractText(arguments[0]);
-                        isFormatString = arguments.Count > 1 || arguments[0].DescendantNodes().OfType<InterpolationSyntax>().Any();
-                        catalog.AddOrUpdateEntry(null, messageId, $"{pathRelative}:{arguments[0].GetLocation().GetLineSpan().StartLinePosition.Line + 1}", isFormatString); ;
+                        if (arguments.Count >= 1)
+                        {
+                            messageId = ExtractText(arguments[0]);
+                            isFormatString = arguments.Count > 1 || arguments[0].DescendantNodes().OfType<InterpolationSyntax>().Any();
+                            catalog.AddOrUpdateEntry(null, messageId, $"{pathRelative}:{arguments[0].GetLocation().GetLineSpan().StartLinePosition.Line + 1}", isFormatString);
+                        }
                         break;
                     case "GetParticularString": //first argument is context, second is message id
-                        context = ExtractText(arguments[0]);
-                        messageId = ExtractText(arguments[1]);
-                        isFormatString = arguments.Count > 2 || arguments[1].DescendantNodes().OfType<InterpolationSyntax>().Any();
-                        catalog.AddOrUpdateEntry(context, messageId, $"{pathRelative}:{arguments[1].GetLocation().GetLineSpan().StartLinePosition.Line + 1}", isFormatString);
+                        if (arguments.Count >= 2)
+                        {
+                            context = ExtractText(arguments[0]);
+                            messageId = ExtractText(arguments[1]);
+                            isFormatString = arguments.Count > 2 || arguments[1].DescendantNodes().OfType<InterpolationSyntax>().Any();
+                            catalog.AddOrUpdateEntry(context, messageId, $"{pathRelative}:{arguments[1].GetLocation().GetLineSpan().StartLinePosition.Line + 1}", isFormatString);
+                        }
                         break;
                     case "GetPluralString": //first argument is message id, second is plural message
-                        messageId = ExtractText(arguments[0]);
-                        plural = ExtractText(arguments[1]);
-                        isFormatString = arguments.Count > 2 || arguments[0].DescendantNodes().OfType<InterpolationSyntax>().Any() || arguments[1].DescendantNodes().OfType<InterpolationSyntax>().Any();
-                        catalog.AddOrUpdateEntry(null, messageId, plural, $"{pathRelative}:{arguments[0].GetLocation().GetLineSpan().StartLinePosition.Line + 1}", isFormatString);
+                        if (arguments.Count >= 2)
+                        {
+                            messageId = ExtractText(arguments[0]);
+                            plural = ExtractText(arguments[1]);
+                            isFormatString = arguments.Count > 2 || arguments[0].DescendantNodes().OfType<InterpolationSyntax>().Any() || arguments[1].DescendantNodes().OfType<InterpolationSyntax>().Any();
+                            catalog.AddOrUpdateEntry(null, messageId, plural, $"{pathRelative}:{arguments[0].GetLocation().GetLineSpan().StartLinePosition.Line + 1}", isFormatString);
+                        }
                         break;
                     case "GetParticularPluralString": //first argument is context, second is message id, third is plural message
-                        context = ExtractText(arguments[0]);
-                        messageId = ExtractText(arguments[1]);
-                        plural = ExtractText(arguments[2]);
-                        isFormatString = arguments.Count > 3 || arguments[1].DescendantNodes().OfType<InterpolationSyntax>().Any() || arguments[2].DescendantNodes().OfType<InterpolationSyntax>().Any();
-                        catalog.AddOrUpdateEntry(context, messageId, plural, $"{pathRelative}:{arguments[1].GetLocation().GetLineSpan().StartLinePosition.Line + 1}", isFormatString);
+                        if (arguments.Count >= 3)
+                        {
+                            context = ExtractText(arguments[0]);
+                            messageId = ExtractText(arguments[1]);
+                            plural = ExtractText(arguments[2]);
+                            isFormatString = arguments.Count > 3 || arguments[1].DescendantNodes().OfType<InterpolationSyntax>().Any() || arguments[2].DescendantNodes().OfType<InterpolationSyntax>().Any();
+                            catalog.AddOrUpdateEntry(context, messageId, plural, $"{pathRelative}:{arguments[1].GetLocation().GetLineSpan().StartLinePosition.Line + 1}", isFormatString);
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
My code contains several other methods named `GetString`. These methods take no arguments.  This causes the extractor to fail with:

```
Unhandled exception: System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at GetText.Extractor.Engine.ParserBase`1.GetStrings(SyntaxTree tree) in /_/src/GetText.Extractor/Engine/ParserBase.cs:line 55
   at GetText.Extractor.Engine.SyntaxTreeParser.<Parse>b__1_1(SyntaxTree tree) in /_/src/GetText.Extractor/Engine/SyntaxTreeParser.cs:line 37
   at System.Threading.Tasks.Dataflow.ActionBlock`1.ProcessMessage(Action`1 action, KeyValuePair`2 messageWithId)
   at System.Threading.Tasks.Dataflow.ActionBlock`1.<>c__DisplayClass6_0.<.ctor>b__0(KeyValuePair`2 messageWithId)
   at System.Threading.Tasks.Dataflow.Internal.TargetCore`1.ProcessMessagesLoopCore()
--- End of stack trace from previous location where exception was thrown ---
   at GetText.Extractor.Engine.SyntaxTreeParser.Parse() in /_/src/GetText.Extractor/Engine/SyntaxTreeParser.cs:line 44
   at GetText.Extractor.Program.Execute(FileInfo source, FileInfo target, Boolean unixStyle, Boolean sortOutput, Boolean verbose) in /_/src/GetText.Extractor/Program.cs:line 50
   at GetText.Extractor.Program.<>c.<<Main>b__1_0>d.MoveNext() in /_/src/GetText.Extractor/Program.cs:line 36
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.AnonymousCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass18_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass13_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass20_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__19_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__6_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass9_0.<<UseExceptionHandler>b__0>d.MoveNext()
```

Ideally, the parser would only consider method invocations on ICatalog instances. However, this seems difficult to achieve. That is why this PR prevents the exception by checking for the number of arguments.