### PR TITLE
Implemented aliases based on command line parameters.

### DIFF
--- a/src/GetText.Extractor/CommandLine/CommandLineOptions.cs
+++ b/src/GetText.Extractor/CommandLine/CommandLineOptions.cs
@@ -42,6 +42,11 @@ namespace GetText.Extractor.CommandLine
 
         internal static Option<bool> SortOutput => new Option<bool>(new[] { "--order", "-o" }, "Sort catalogue entries before exporting to template");
 
+        internal static Option<List<string>> GetStringAliases => new Option<List<string>>(new[] { "--aliasgetstring", "-as" }, "List of aliases for GetString");
+        internal static Option<List<string>> GetParticularStringAliases => new Option<List<string>>(new[] { "--aliasgetparticular", "-ad" }, "List of aliases for GetParticularString");
+        internal static Option<List<string>> GetPluralStringAliases => new Option<List<string>>(new[] { "--aliasgetplural", "-ap" }, "List of aliases for GetPluralString");
+        internal static Option<List<string>> GetParticularPluralStringAliases => new Option<List<string>>(new[] { "--aliasgetparticularplural", "-adp" }, "List of aliases for GetParticularPluralString");
+
         #region private validation and parsing
         private static FileInfo TryParseDefaultTargetFile(ArgumentResult argument)
         {

--- a/src/GetText.Extractor/CommandLine/CommandLineOptions.cs
+++ b/src/GetText.Extractor/CommandLine/CommandLineOptions.cs
@@ -42,10 +42,10 @@ namespace GetText.Extractor.CommandLine
 
         internal static Option<bool> SortOutput => new Option<bool>(new[] { "--order", "-o" }, "Sort catalogue entries before exporting to template");
 
-        internal static Option<List<string>> GetStringAliases => new Option<List<string>>(new[] { "--aliasgetstring", "-as" }, "List of aliases for GetString");
-        internal static Option<List<string>> GetParticularStringAliases => new Option<List<string>>(new[] { "--aliasgetparticular", "-ad" }, "List of aliases for GetParticularString");
-        internal static Option<List<string>> GetPluralStringAliases => new Option<List<string>>(new[] { "--aliasgetplural", "-ap" }, "List of aliases for GetPluralString");
-        internal static Option<List<string>> GetParticularPluralStringAliases => new Option<List<string>>(new[] { "--aliasgetparticularplural", "-adp" }, "List of aliases for GetParticularPluralString");
+        internal static Option<List<string>> GetStringAliases => new Option<List<string>>(new[] { "--aliasgetstring", "-as" }, "List of aliases for GetString") { AllowMultipleArgumentsPerToken = true };
+        internal static Option<List<string>> GetParticularStringAliases => new Option<List<string>>(new[] { "--aliasgetparticular", "-ad" }, "List of aliases for GetParticularString") { AllowMultipleArgumentsPerToken = true };
+        internal static Option<List<string>> GetPluralStringAliases => new Option<List<string>>(new[] { "--aliasgetplural", "-ap" }, "List of aliases for GetPluralString") { AllowMultipleArgumentsPerToken = true };
+        internal static Option<List<string>> GetParticularPluralStringAliases => new Option<List<string>>(new[] { "--aliasgetparticularplural", "-adp" }, "List of aliases for GetParticularPluralString") { AllowMultipleArgumentsPerToken = true };
 
         #region private validation and parsing
         private static FileInfo TryParseDefaultTargetFile(ArgumentResult argument)

--- a/src/GetText.Extractor/Engine/Aliases.cs
+++ b/src/GetText.Extractor/Engine/Aliases.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GetText.Extractor.Engine
+{
+    internal class Aliases
+    {
+        public List<string> GetString { get; set; }
+        public List<string> GetParticularString { get; set; }
+        public List<string> GetPluralString { get; set; }
+        public List<string> GetParticularPluralString { get; set; }
+    }
+}

--- a/src/GetText.Extractor/Engine/ParserBase.cs
+++ b/src/GetText.Extractor/Engine/ParserBase.cs
@@ -36,10 +36,10 @@ namespace GetText.Extractor.Engine
             this.verbose = verbose;
             this.unixStyle = unixStyle;
 
-            GetStringAliases = aliases.GetString?.ToHashSet();
-            GetParticularStringAliases = aliases.GetParticularString?.ToHashSet();
-            GetPluralStringAliases = aliases.GetPluralString?.ToHashSet();
-            GetParticularPluralStringAliases = aliases.GetParticularPluralString?.ToHashSet();
+            GetStringAliases = new List<string>() { "GetString" }.Concat(aliases.GetString ?? Enumerable.Empty<string>()).ToHashSet();
+            GetParticularStringAliases = new List<string>() { "GetParticularString" }.Concat(aliases.GetParticularString ?? Enumerable.Empty<string>()).ToHashSet();
+            GetPluralStringAliases = new List<string>() { "GetPluralString" }.Concat(aliases.GetPluralString ?? Enumerable.Empty<string>()).ToHashSet();
+            GetParticularPluralStringAliases = new List<string>() { "GetParticularPluralString" }.Concat(aliases.GetParticularPluralString ?? Enumerable.Empty<string>()).ToHashSet();
             CatalogMethods = GetStringAliases.Concat(GetParticularStringAliases).Concat(GetPluralStringAliases).Concat(GetParticularPluralStringAliases).ToHashSet();
         }
 

--- a/src/GetText.Extractor/Engine/SyntaxTreeParser.cs
+++ b/src/GetText.Extractor/Engine/SyntaxTreeParser.cs
@@ -17,8 +17,8 @@ namespace GetText.Extractor.Engine
     {
         private readonly IList<FileInfo> sources;
 
-        public SyntaxTreeParser(CatalogTemplate catalog, IList<FileInfo> sources, bool unixStyle, bool verbose) :
-            base(catalog, unixStyle, verbose)
+        public SyntaxTreeParser(CatalogTemplate catalog, IList<FileInfo> sources, bool unixStyle, bool verbose, Aliases aliases) :
+            base(catalog, unixStyle, verbose, aliases)
         {
             this.sources = sources;
             catalog.Header.ProjectIdVersion = Path.GetFileNameWithoutExtension(sources.First().Name);

--- a/src/GetText.Extractor/Program.cs
+++ b/src/GetText.Extractor/Program.cs
@@ -31,11 +31,6 @@ namespace GetText.Extractor
             Option aliasPlural = CommandLineOptions.GetPluralStringAliases;
             Option aliasDefinitePlural = CommandLineOptions.GetParticularPluralStringAliases;
 
-            aliasString.AllowMultipleArgumentsPerToken = true;
-            aliasDefinite.AllowMultipleArgumentsPerToken = true;
-            aliasPlural.AllowMultipleArgumentsPerToken = true;
-            aliasDefinitePlural.AllowMultipleArgumentsPerToken = true;
-
             rootCommand.Add(sourceOption);
             rootCommand.Add(outFile);
             rootCommand.Add(verbose);
@@ -62,10 +57,10 @@ namespace GetText.Extractor
             catalog = new CatalogTemplate(target.FullName);
 
             SyntaxTreeParser parser = new SyntaxTreeParser(catalog, sources, unixStyle, verbose, new Aliases()
-            {   GetString = new List<string>() { "GetString" }.Concat(getStringAliases).ToList(),
-                GetParticularString = new List<string>() { "GetParticularString" }.Concat(getParticularStringAliases).ToList(),
-                GetPluralString = new List<string>() { "GetPluralString" }.Concat(getPluralStringAliases).ToList(),
-                GetParticularPluralString = new List<string>() { "GetParticularPluralString" }.Concat(getParticularPluralStringAliases).ToList() });
+            {   GetString = getStringAliases,
+                GetParticularString = getParticularStringAliases,
+                GetPluralString = getPluralStringAliases,
+                GetParticularPluralString = getParticularPluralStringAliases });
             await parser.Parse().ConfigureAwait(false);
 
             await catalog.WriteAsync(sortOutput).ConfigureAwait(false);

--- a/src/GetText.Extractor/Program.cs
+++ b/src/GetText.Extractor/Program.cs
@@ -2,6 +2,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -25,27 +26,46 @@ namespace GetText.Extractor
             Option verbose = CommandLineOptions.Verbose;
             Option unixPathSeparator = CommandLineOptions.UseUnixPathSeparator;
             Option sort = CommandLineOptions.SortOutput;
+            Option aliasString = CommandLineOptions.GetStringAliases;
+            Option aliasDefinite = CommandLineOptions.GetParticularStringAliases;
+            Option aliasPlural = CommandLineOptions.GetPluralStringAliases;
+            Option aliasDefinitePlural = CommandLineOptions.GetParticularPluralStringAliases;
+
+            aliasString.AllowMultipleArgumentsPerToken = true;
+            aliasDefinite.AllowMultipleArgumentsPerToken = true;
+            aliasPlural.AllowMultipleArgumentsPerToken = true;
+            aliasDefinitePlural.AllowMultipleArgumentsPerToken = true;
 
             rootCommand.Add(sourceOption);
             rootCommand.Add(outFile);
             rootCommand.Add(verbose);
             rootCommand.Add(unixPathSeparator);
             rootCommand.Add(sort);
+            rootCommand.Add(aliasString);
+            rootCommand.Add(aliasDefinite);
+            rootCommand.Add(aliasPlural);
+            rootCommand.Add(aliasDefinitePlural);
 
-            rootCommand.SetHandler(async (IList<FileInfo> sources, FileInfo target, bool unixstyle, bool sortOutput, bool verbose) =>
+            rootCommand.SetHandler(async (IList<FileInfo> sources, FileInfo target, bool unixstyle, bool sortOutput, bool verbose,
+                List<string> @as, List<string> ad, List<string> ap, List<string> adp) =>
             {
-                await Execute(sources, target, unixstyle, sortOutput, verbose).ConfigureAwait(false);
-            }, sourceOption, outFile, unixPathSeparator, sort, verbose);
+                await Execute(sources, target, unixstyle, sortOutput, verbose, @as, ad, ap, adp).ConfigureAwait(false);
+            }, sourceOption, outFile, unixPathSeparator, sort, verbose, aliasString, aliasDefinite, aliasPlural, aliasDefinitePlural);
 
             return await rootCommand.InvokeAsync(args).ConfigureAwait(false);
 
         }
 
-        private static async Task Execute(IList<FileInfo> sources, FileInfo target, bool unixStyle, bool sortOutput, bool verbose)
+        private static async Task Execute(IList<FileInfo> sources, FileInfo target, bool unixStyle, bool sortOutput, bool verbose,
+            List<string> getStringAliases, List<string> getParticularStringAliases, List<string> getPluralStringAliases, List<string> getParticularPluralStringAliases)
         {
             catalog = new CatalogTemplate(target.FullName);
 
-            SyntaxTreeParser parser = new SyntaxTreeParser(catalog, sources, unixStyle, verbose);
+            SyntaxTreeParser parser = new SyntaxTreeParser(catalog, sources, unixStyle, verbose, new Aliases()
+            {   GetString = new List<string>() { "GetString" }.Concat(getStringAliases).ToList(),
+                GetParticularString = new List<string>() { "GetParticularString" }.Concat(getParticularStringAliases).ToList(),
+                GetPluralString = new List<string>() { "GetPluralString" }.Concat(getPluralStringAliases).ToList(),
+                GetParticularPluralString = new List<string>() { "GetParticularPluralString" }.Concat(getParticularPluralStringAliases).ToList() });
             await parser.Parse().ConfigureAwait(false);
 
             await catalog.WriteAsync(sortOutput).ConfigureAwait(false);


### PR DESCRIPTION
This should implement the generic solution to #36 's alias addition. It uses command line parameters, so it can get pretty wordy. If using a config library would be preferable, [https://github.com/dotnetconfig/dotnet-config](url) appears to be something that would work.