### PR TITLE
Fix extractor reference races and deduplicate source references

### DIFF
--- a/src/GetText.Extractor/Template/CatalogTemplate.cs
+++ b/src/GetText.Extractor/Template/CatalogTemplate.cs
@@ -47,7 +47,8 @@ namespace GetText.Extractor.Template
             lock (result)
             {
                 result.PluralMessageId = plural;
-                result.References.Add(reference);
+                if (!result.References.Contains(reference))
+                    result.References.Add(reference);
                 result.Comments.Flags = formatString ? result.Comments.Flags | MessageFlags.CSharpFormat : result.Comments.Flags & ~MessageFlags.CSharpFormat;
             }
         }

--- a/src/GetText.Extractor/Template/CatalogTemplate.cs
+++ b/src/GetText.Extractor/Template/CatalogTemplate.cs
@@ -28,30 +28,28 @@ namespace GetText.Extractor.Template
         {
             if (messageId == null || string.IsNullOrWhiteSpace(System.Text.RegularExpressions.Regex.Unescape(messageId)))
                 return;     // don't care about empty message ids
-            if (!entries.TryGetValue(CatalogEntry.BuildKey(context, messageId), out CatalogEntry result))
+            CatalogEntry result = GetOrAddEntry(context, messageId);
+
+            lock (result)
             {
-                result = new CatalogEntry(context, messageId);
-                if (!entries.TryAdd(result.Key, result))
-                    result = entries[result.Key];
+                if (!result.References.Contains(reference))
+                    result.References.Add(reference);
+                result.Comments.Flags = formatString ? result.Comments.Flags | MessageFlags.CSharpFormat : result.Comments.Flags & ~MessageFlags.CSharpFormat;
             }
-            if (!result.References.Contains(reference))
-                result.References.Add(reference);
-            result.Comments.Flags = formatString ? result.Comments.Flags | MessageFlags.CSharpFormat : result.Comments.Flags & ~MessageFlags.CSharpFormat;
         }
 
         public void AddOrUpdateEntry(string context, string messageId, string plural, string reference, bool formatString)
         {
             if (string.IsNullOrEmpty(messageId))
                 return;     // don't care about empty message ids
-            if (!entries.TryGetValue(CatalogEntry.BuildKey(context, messageId), out CatalogEntry result))
+            CatalogEntry result = GetOrAddEntry(context, messageId);
+
+            lock (result)
             {
-                result = new CatalogEntry(context, messageId);
-                if (!entries.TryAdd(result.Key, result))
-                    result = entries[result.Key];
+                result.PluralMessageId = plural;
+                result.References.Add(reference);
+                result.Comments.Flags = formatString ? result.Comments.Flags | MessageFlags.CSharpFormat : result.Comments.Flags & ~MessageFlags.CSharpFormat;
             }
-            result.PluralMessageId = plural;
-            result.References.Add(reference);
-            result.Comments.Flags = formatString ? result.Comments.Flags | MessageFlags.CSharpFormat : result.Comments.Flags & ~MessageFlags.CSharpFormat;
         }
 
         public async Task WriteAsync(bool sort)
@@ -95,6 +93,20 @@ namespace GetText.Extractor.Template
             {
                 await writer.WriteAsync(ToString()).ConfigureAwait(false);
             }
+        }
+
+        private CatalogEntry GetOrAddEntry(string context, string messageId)
+        {
+            if (!entries.TryGetValue(CatalogEntry.BuildKey(context, messageId), out CatalogEntry result))
+            {
+                result = new CatalogEntry(context, messageId);
+                if (!entries.TryAdd(result.Key, result))
+                {
+                    result = entries[result.Key];
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/test/GetText.Extractor.Tests/Template/CatalogTemplateTests.cs
+++ b/test/GetText.Extractor.Tests/Template/CatalogTemplateTests.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using GetText.Extractor.Template;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GetText.Extractor.Tests.Template
+{
+    [TestClass]
+    public class CatalogTemplateTests
+    {
+        [TestMethod]
+        public void DuplicateReferenceIsAddedOnlyOnce()
+        {
+            CatalogTemplate catalog = new CatalogTemplate(Path.GetTempFileName());
+
+            // Add the identical reference 2 times
+            catalog.AddOrUpdateEntry(null, "Shared text", "File1.cs:10", false);
+            catalog.AddOrUpdateEntry(null, "Shared text", "File1.cs:10", false);
+
+            CatalogEntry entry = catalog.entries.Single().Value;
+
+            // Only a single reference is expected
+            Assert.AreEqual(1, entry.References.Count);
+            Assert.AreEqual("File1.cs:10", entry.References.Single());
+        }
+
+        [TestMethod]
+        public void DuplicatePluralReferenceIsAddedOnlyOnce()
+        {
+            CatalogTemplate catalog = new CatalogTemplate(Path.GetTempFileName());
+
+            // Add the identical reference 2 times
+            catalog.AddOrUpdateEntry(null, "One file", "Many files", "File1.cs:10", false);
+            catalog.AddOrUpdateEntry(null, "One file", "Many files", "File1.cs:10", false);
+
+            CatalogEntry entry = catalog.entries.Single().Value;
+
+            // Only a single reference is expected
+            Assert.AreEqual(1, entry.References.Count);
+            Assert.AreEqual("File1.cs:10", entry.References.Single());
+        }
+        [TestMethod]
+        public async Task ConcurrentReferenceUpdatesKeepAllUniqueReferences()
+        {
+            CatalogTemplate catalog = new CatalogTemplate(Path.GetTempFileName());
+            string[] references = Enumerable.Range(1, 256).Select(i => $"File{i}.cs:10").ToArray();
+
+            await Parallel.ForEachAsync(references, (reference, token) =>
+            {
+                catalog.AddOrUpdateEntry(null, "Shared text", reference, false);
+                return ValueTask.CompletedTask;
+            }).ConfigureAwait(false);
+
+            CatalogEntry entry = catalog.entries.Single().Value;
+            Assert.AreEqual(references.Length, entry.References.Count);
+            CollectionAssert.AreEquivalent(references, entry.References);
+        }
+    }
+}


### PR DESCRIPTION
Fix issue in `GetText.Extractor`, where source references in generated .pot could be incomplete. And also an issue that those references can contain duplicates, when plural form is used.

- Made `CatalogTemplate.AddOrUpdateEntry(...)` updates thread-safe per catalog entry. This fixed nondeterministic loss of source references during parallel extraction.
- In `CatalogTemplate.AddOrUpdateEntry(..)` with plural form: reference is now added only when it is not added before, the same way as it already was done in non plural version if this method.

Also extracted some duplicate logic into the newly introduced `CatalogTemplate.GetOrAddEntry(...)`.

Added unit tests to verify both issues

- [x] All Unit tests are passing